### PR TITLE
Aws/vpc module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Ignore tfvars in module folder
+**/modules/**/*.tfvars

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # terraform-playground
+
+Purpose:
+This repository provide code samples developed to demonstrate Terraform usage.
+
+### Usage
+To install terraform, see the Hashicorp website here [https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+
+You can use terraform from the command line like:
+```shell
+terraform plan
+terraform apply
+
+```
+
+### Modules
+This repo contains the following modules:
+- s3: see [/aws/modules/s3](/aws/modules/s3/)
+- vpc: see [/aws/modules/vpc](/aws/modules/vpc/)

--- a/aws/modules/vpc/README.md
+++ b/aws/modules/vpc/README.md
@@ -1,0 +1,43 @@
+# Module: vpc
+
+### Inputs
+This module requires the following inputs:
+
+| Variable                   | Type         | Description                                        |
+|----------------------------|--------------|----------------------------------------------------|
+| region                     | String       | AWS region eg. us-west-2                           |
+| cidr_block                 | String       | IP range for the entire network eg. 192.168.0.0/24 |
+| enable_dns_hostnames       | Bool         | True/False if you want to enable hostnames         |
+| public_subnet_cidr_blocks  | List[String] |                                                    |
+| private_subnet_cidr_blocks | List[String] |                                                    |
+
+### Usage
+
+To use this module, specify the source with the required inputs:
+```terraform
+module "my-vpc" {
+  source               = "./vpc"
+  region               = "ap-southeast-2"
+  cidr_block           = "192.168.0.0/16"
+  enable_dns_hostnames = true
+}
+```
+
+### Outputs
+
+Once the module has completed you can access the following:
+
+| Variable            | Type         | Description                                           |
+|---------------------|--------------|-------------------------------------------------------|
+| vpc_id              | String       | AWS Resource id for the VPC eg. vpc-1234              |
+| public_subnets_ids  | String       | List of AWS resource ids eg. ["subnet-1", "subnet-2"] |
+| private_subnets_ids | Bool         | List of AWS resource ids eg. ["subnet-3", "subnet-4"] |
+
+This can be done by referencing the instance like so:
+```terraform
+module "sample" {
+  source          = "./sample"
+  input_variables = module.my-vpc.vpc_id
+  ...
+}
+```

--- a/aws/modules/vpc/README.md
+++ b/aws/modules/vpc/README.md
@@ -1,34 +1,36 @@
 # Module: vpc
 
 ### Purpose
-This module ...
+
+This module creates a generic VPC. It supports creation of public and private subnets (up to the number of AZs available to the specified region). Currently, it only allows creation of an internet gateway (associated with public subnets) and a NAT gateway (associated with private subnets).
 
 It creates the following resources
+
 - aws_vpc
 - aws_subnet
 - aws_internet_gateway
-- aws_route_table
-- aws_route_table_association
+- aws_route_table (one for each of public and private subnets)
+- aws_route_table_association (one for each of public and private subnets)
 - aws_eip
 - aws_nat_gateway
-- aws_route_table
-- aws_route_table_association
-
 
 ### Inputs
+
 This module requires the following inputs:
 
-| Variable                   | Type         | Description                                        |
-|----------------------------|--------------|----------------------------------------------------|
-| region                     | String       | AWS region eg. us-west-2                           |
-| cidr_block                 | String       | IP range for the entire network eg. 192.168.0.0/24 |
-| enable_dns_hostnames       | Bool         | True/False if you want to enable hostnames         |
-| public_subnet_cidr_blocks  | List[String] |                                                    |
-| private_subnet_cidr_blocks | List[String] |                                                    |
+| Variable                   | Type         | Description                                              |
+| -------------------------- | ------------ | -------------------------------------------------------- |
+| name_prefix                | String       | Prefix for tagging purposes                              |
+| region                     | String       | AWS region eg. us-west-2                                 |
+| cidr_block                 | String       | IP range for the entire network eg. 192.168.0.0/24       |
+| enable_dns_hostnames       | Bool         | True/False if you want to enable hostnames               |
+| public_subnet_cidr_blocks  | List[String] | List of CIDR blocks corresponding to the public subnets  |
+| private_subnet_cidr_blocks | List[String] | List of CIDR blocks corresponding to the private subnets |
 
 ### Usage
 
 To use this module, specify the source with the required inputs:
+
 ```terraform
 module "my-vpc" {
   source               = "./vpc"
@@ -42,13 +44,20 @@ module "my-vpc" {
 
 Once the module has completed you can access the following:
 
-| Variable            | Type         | Description                                           |
-|---------------------|--------------|-------------------------------------------------------|
-| vpc_id              | String       | AWS Resource id for the VPC eg. vpc-1234              |
-| public_subnets_ids  | String       | List of AWS resource ids eg. ["subnet-1", "subnet-2"] |
-| private_subnets_ids | Bool         | List of AWS resource ids eg. ["subnet-3", "subnet-4"] |
+| Variable                       | Type         | Description                                                                                    |
+| ------------------------------ | ------------ | ---------------------------------------------------------------------------------------------- |
+| vpc_id                         | String       | AWS Resource id for the VPC eg. vpc-1234                                                       |
+| vpc_cidr_block                 | String       | CIDR block for provisioned VPC eg. 10.0.0.0/16                                                 |
+| availability_zones             | List[String] | List of availability zones for the specified region eg. ["ap-southeast-2a", "ap-southeast-2b"] |
+| internet_gateway_id            | String       | AWS Resource id for the provisioned internet gateway                                           |
+| public_subnets_ids             | String       | List of AWS resource ids eg. ["subnet-1", "subnet-2"]                                          |
+| public_subnets_route_table_id  | String       | AWS Resource id for the provisioned route table associated with public subnets                 |
+| nat_gateway_id                 | String       | AWS Resource id for the provisioned NAT gateway for private subnets                            |
+| private_subnets_ids            | Bool         | List of AWS resource ids eg. ["subnet-3", "subnet-4"]                                          |
+| private_subnets_route_table_id | String       | AWS Resource id for the provisioned route table associated with private subnets                |
 
 This can be done by referencing the instance like so:
+
 ```terraform
 module "sample" {
   source          = "./sample"

--- a/aws/modules/vpc/README.md
+++ b/aws/modules/vpc/README.md
@@ -1,5 +1,20 @@
 # Module: vpc
 
+### Purpose
+This module ...
+
+It creates the following resources
+- aws_vpc
+- aws_subnet
+- aws_internet_gateway
+- aws_route_table
+- aws_route_table_association
+- aws_eip
+- aws_nat_gateway
+- aws_route_table
+- aws_route_table_association
+
+
 ### Inputs
 This module requires the following inputs:
 

--- a/aws/modules/vpc/main.tf
+++ b/aws/modules/vpc/main.tf
@@ -1,0 +1,103 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "default" {
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = var.enable_dns_hostnames
+}
+
+resource "aws_subnet" "public" {
+  count = min(length(var.public_subnet_cidr_blocks), length(data.aws_availability_zones.default.id))
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.public_subnet_cidr_blocks[count.index]
+  availability_zone = data.aws_availability_zones.default.names[count.index]
+
+  tags = {
+    Name = "public-subnet-${count.index}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  count = min(length(var.private_subnet_cidr_blocks), length(data.aws_availability_zones.default.id))
+
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr_blocks[count.index]
+  availability_zone = data.aws_availability_zones.default.names[count.index]
+
+  tags = {
+    Name = "private-subnet-${count.index}"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  depends_on = [aws_internet_gateway.main]
+
+  tags = {
+    Name = "public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(aws_subnet.public)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_eip" "nat_gateway_ip" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = length(var.private_subnet_cidr_blocks) >= 1 ? 1 : 0
+  subnet_id     = aws_subnet.private[0].id
+  allocation_id = aws_eip.nat_gateway_ip.id
+}
+
+resource "aws_route_table" "private" {
+  count  = length(var.private_subnet_cidr_blocks) >= 1 ? 1 : 0
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[0].id
+  }
+
+  depends_on = [aws_nat_gateway.main]
+
+  tags = {
+    Name = "private"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[0].id
+}

--- a/aws/modules/vpc/main.tf
+++ b/aws/modules/vpc/main.tf
@@ -17,6 +17,10 @@ data "aws_availability_zones" "default" {
 resource "aws_vpc" "main" {
   cidr_block           = var.cidr_block
   enable_dns_hostnames = var.enable_dns_hostnames
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
 }
 
 resource "aws_subnet" "public" {
@@ -27,7 +31,7 @@ resource "aws_subnet" "public" {
   availability_zone = data.aws_availability_zones.default.names[count.index]
 
   tags = {
-    Name = "public-subnet-${count.index}"
+    Name = "${var.name_prefix}-public-subnet-${count.index}"
   }
 }
 
@@ -39,12 +43,16 @@ resource "aws_subnet" "private" {
   availability_zone = data.aws_availability_zones.default.names[count.index]
 
   tags = {
-    Name = "private-subnet-${count.index}"
+    Name = "${var.name_prefix}-private-subnet-${count.index}"
   }
 }
 
 resource "aws_internet_gateway" "main" {
   vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
 }
 
 resource "aws_route_table" "public" {
@@ -58,7 +66,7 @@ resource "aws_route_table" "public" {
   depends_on = [aws_internet_gateway.main]
 
   tags = {
-    Name = "public"
+    Name = "${var.name_prefix}-public-route-table"
   }
 }
 
@@ -77,6 +85,10 @@ resource "aws_nat_gateway" "main" {
   count         = length(var.private_subnet_cidr_blocks) >= 1 ? 1 : 0
   subnet_id     = aws_subnet.private[0].id
   allocation_id = aws_eip.nat_gateway_ip.id
+
+  tags = {
+    Name = "${var.name_prefix}-nat-gateway"
+  }
 }
 
 resource "aws_route_table" "private" {
@@ -91,7 +103,7 @@ resource "aws_route_table" "private" {
   depends_on = [aws_nat_gateway.main]
 
   tags = {
-    Name = "private"
+    Name = "${var.name_prefix}-private-route-table"
   }
 }
 

--- a/aws/modules/vpc/outputs.tf
+++ b/aws/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.main.id
+}
+
+output "public_subnets_ids" {
+  value = aws_subnet.public.*.id
+}
+
+output "private_subnets_ids" {
+  value = aws_subnet.private.*.id
+}

--- a/aws/modules/vpc/outputs.tf
+++ b/aws/modules/vpc/outputs.tf
@@ -2,10 +2,34 @@ output "vpc_id" {
   value = aws_vpc.main.id
 }
 
+output "vpc_cidr_block" {
+  value = aws_vpc.main.cidr_block
+}
+
+output "availability_zones" {
+  value = data.aws_availability_zones.default
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.main.id
+}
+
 output "public_subnets_ids" {
   value = aws_subnet.public.*.id
 }
 
+output "public_subnets_route_table_id" {
+  value = aws_route_table.public.id
+}
+
+output "nat_gateway_id" {
+  value = aws_nat_gateway.main.id
+}
+
 output "private_subnets_ids" {
   value = aws_subnet.private.*.id
+}
+
+output "private_subnets_route_table_id" {
+  value = aws_route_table.private.id
 }

--- a/aws/modules/vpc/outputs.tf
+++ b/aws/modules/vpc/outputs.tf
@@ -7,7 +7,7 @@ output "vpc_cidr_block" {
 }
 
 output "availability_zones" {
-  value = data.aws_availability_zones.default
+  value = data.aws_availability_zones.default.names
 }
 
 output "internet_gateway_id" {
@@ -23,7 +23,7 @@ output "public_subnets_route_table_id" {
 }
 
 output "nat_gateway_id" {
-  value = aws_nat_gateway.main.id
+  value = aws_nat_gateway.main[0].id
 }
 
 output "private_subnets_ids" {
@@ -31,5 +31,5 @@ output "private_subnets_ids" {
 }
 
 output "private_subnets_route_table_id" {
-  value = aws_route_table.private.id
+  value = aws_route_table.private[0].id
 }

--- a/aws/modules/vpc/vars.tf
+++ b/aws/modules/vpc/vars.tf
@@ -1,8 +1,14 @@
+variable "name_prefix" {
+  type = string
+}
+
 variable "region" {
+  type    = string
   default = "ap-southeast-2"
 }
 
 variable "cidr_block" {
+  type        = string
   description = "CIDR block for VPC"
   default     = "10.0.0.0/16"
 }
@@ -12,11 +18,13 @@ variable "enable_dns_hostnames" {
 }
 
 variable "public_subnet_cidr_blocks" {
+  type        = list[string]
   description = "List of CIDR blocks for the public subnets"
   default     = ["10.0.0.0/24", "10.0.1.0/24"]
 }
 
 variable "private_subnet_cidr_blocks" {
+  type        = list[string]
   description = "List of CIDR blocks for the private subnets"
   default     = []
 }

--- a/aws/modules/vpc/vars.tf
+++ b/aws/modules/vpc/vars.tf
@@ -1,0 +1,22 @@
+variable "region" {
+  default = "ap-southeast-2"
+}
+
+variable "cidr_block" {
+  description = "CIDR block for VPC"
+  default     = "10.0.0.0/16"
+}
+
+variable "enable_dns_hostnames" {
+  default = true
+}
+
+variable "public_subnet_cidr_blocks" {
+  description = "List of CIDR blocks for the public subnets"
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+}
+
+variable "private_subnet_cidr_blocks" {
+  description = "List of CIDR blocks for the private subnets"
+  default     = []
+}

--- a/aws/modules/vpc/vars.tf
+++ b/aws/modules/vpc/vars.tf
@@ -18,13 +18,13 @@ variable "enable_dns_hostnames" {
 }
 
 variable "public_subnet_cidr_blocks" {
-  type        = list[string]
+  type        = list(string)
   description = "List of CIDR blocks for the public subnets"
   default     = ["10.0.0.0/24", "10.0.1.0/24"]
 }
 
 variable "private_subnet_cidr_blocks" {
-  type        = list[string]
+  type        = list(string)
   description = "List of CIDR blocks for the private subnets"
   default     = []
 }


### PR DESCRIPTION
## Description
Created a basic VPC module with AWS, currently allows:
- creation of n (up to the maximum number of AZ in the user's region) public and private subnets
- creation of two route tables, one for public subnets and one for private subnets
- creation of an internet gateway for public subnets and a NAT gateway for private subnets